### PR TITLE
Update project to support kernel version 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up kernel headers
+      run: sudo apt-get install -y linux-headers-$(uname -r)
+
+    - name: Install dependencies
+      run: sudo apt-get install -y build-essential
+
+    - name: Build project
+      run: make -C sources/transmitter/module
+
+    - name: Run tests
+      run: make -C sources/transmitter/tester

--- a/sources/transmitter/module/gpiowire.c
+++ b/sources/transmitter/module/gpiowire.c
@@ -65,14 +65,7 @@ inline int gpio_set_pin(struct device_data* data, int value)
     value = (value ? 0 : 1);
   }
 
-  if (data->attr_can_sleep)
-  {
-    gpio_set_value_cansleep(data->attr_pin_number, value);
-  }
-  else
-  {
-    gpio_set_value(data->attr_pin_number, value); 
-  }
+  gpio_set_value(data->attr_pin_number, value); 
 
   return value;
 }
@@ -487,7 +480,7 @@ int file_open(struct inode *inodep, struct file *filep)
 
   sprintf(pinLabel, "pin %ud", data->attr_pin_number);
 
-  result = gpio_request(data->attr_pin_number, pinLabel); 
+  result = gpiod_request(data->attr_pin_number, pinLabel); 
 
   if (result < 0)
   {
@@ -499,7 +492,7 @@ int file_open(struct inode *inodep, struct file *filep)
    
   LOG_DEV(debug, "gpio pin %d successfully reserved.\n", data->attr_pin_number);
 
-  result = gpio_export(data->attr_pin_number, false); 
+  result = gpiod_export(data->attr_pin_number, false); 
 
   if (result < 0)
   {
@@ -511,7 +504,7 @@ int file_open(struct inode *inodep, struct file *filep)
    
   LOG_DEV(debug, "gpio pin %d successfully exported.\n", data->attr_pin_number);
 
-  result = gpio_direction_output(data->attr_pin_number, data->attr_swap_output);
+  result = gpiod_direction_output(data->attr_pin_number, data->attr_swap_output);
 
   if (result < 0)
   {
@@ -553,8 +546,8 @@ int file_release(struct inode *inodep, struct file *filep)
 
   if (data->attr_pin_number > 0)
   {
-    gpio_unexport(data->attr_pin_number);
-    gpio_free(data->attr_pin_number);
+    gpiod_unexport(data->attr_pin_number);
+    gpiod_free(data->attr_pin_number);
   }
 
   mutex_unlock(&data->mutex);

--- a/sources/transmitter/module/gpiowire.h
+++ b/sources/transmitter/module/gpiowire.h
@@ -12,7 +12,7 @@
 
 #include <linux/device.h>  // Header to support the kernel Driver Model
 #include <linux/fs.h>      // Header for the Linux file system support
-#include <linux/gpio.h>    // Required for the GPIO functions
+#include <linux/gpio/consumer.h> // Required for the GPIO functions
 #include <linux/hrtimer.h> // High Resolution Timers
 #include <linux/init.h>    // Macros used to mark up functions __init __exit
 #include <linux/kernel.h>  // Contains types, macros, functions for the kernel


### PR DESCRIPTION
Update the code to be compatible with Linux kernel version 6.

* **gpiowire.c**
  - Replace `gpio_set_value_cansleep` with `gpio_set_value`.
  - Replace `gpio_request` with `gpiod_request`.
  - Replace `gpio_export` with `gpiod_export`.
  - Replace `gpio_direction_output` with `gpiod_direction_output`.
  - Replace `gpio_unexport` with `gpiod_unexport`.
  - Replace `gpio_free` with `gpiod_free`.

* **gpiowire.h**
  - Update the `#include` directive to include the necessary header for kernel version 6.

* **build.yml**
  - Add a new GitHub Actions workflow file to build the project on Ubuntu 22.04 with kernel 6.
  - Define steps to check out the repository, set up kernel headers, install dependencies, build the project, and run tests.

